### PR TITLE
fix(eleicao): remove cache for plugins with form

### DIFF
--- a/app/eleicao/cms_plugins.py
+++ b/app/eleicao/cms_plugins.py
@@ -45,6 +45,7 @@ class EleicaoCandidateListPlugin(CMSPluginBase):
     module = "A Eleição do Ano"
     render_template = "eleicao/plugins/candidate_list.html"
     per_page = 20
+    cache = False
 
     def render(self, context, instance, placeholder):
         ctx = super().render(context, instance, placeholder)


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
<!-- Qual problema esse PR resolve? -->
Remove cache do plugin Listagem de Candidaturas

Objetivo principal é testar o filtro de candidaturas que está intermitente