### PR TITLE
Fix: Remove campo "newsletter" e troca a ordem o botão de Submit no Eleitor Form

### DIFF
--- a/app/eleicao/forms/create.py
+++ b/app/eleicao/forms/create.py
@@ -18,7 +18,7 @@ class PlacesWidget(s2forms.ModelSelect2Widget):
 class VoterForm(forms.ModelForm):
     class Meta:
         model = Voter
-        fields = ["name", "email", "whatsapp", "state", "city", "place", "newsletter"]
+        fields = ["name", "email", "whatsapp", "state", "city", "place"]
         widgets = {
             "name": forms.TextInput(attrs={"placeholder": "Seu nome completo"}),
             "email": forms.EmailInput(attrs={"placeholder": "Seu email"}),

--- a/app/eleicao/templates/eleicao/plugins/voter_form.html
+++ b/app/eleicao/templates/eleicao/plugins/voter_form.html
@@ -32,9 +32,9 @@
             {% endfor %}
           </div>
 
-          <p class="text-sm">Ao inserir seus dados, você concorda em ter seus dados compartilhados com os organizadores dessa página e aceita receber emails de atualização, conforme descrito na  <a class="font-bold" href="{% static 'politica-de-privacidade.pdf' %}" target="_blank">política de privacidade</a>. Você pode cancelar o recebimento desses e-mails a qualquer momento.</p>
-
           <button type="submit" class="btn w-full bg-[#93AC70] hover:bg-[#758e53] text-white">Quero descobrir</button>
+
+          <p class="text-sm">Ao inserir seus dados, você concorda em ter seus dados compartilhados com os organizadores dessa página e aceita receber emails de atualização, conforme descrito na  <a class="font-bold" href="{% static 'politica-de-privacidade.pdf' %}" target="_blank">política de privacidade</a>. Você pode cancelar o recebimento desses e-mails a qualquer momento.</p>
         </form>
       </div>
     </div>


### PR DESCRIPTION
### Contexto
Remove campo "newsletter" e troca a ordem o botão de Submit

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205417206565363/f

### Requisitos
- [x] Remover campo "newsletter" dentro do `create.py`
- [x] Alterar a ordem do botão de submit para estar acima da política de privacidade, seguindo o Figma 

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/d3da16b8-c3e2-4430-9778-40eb6c92ac51)
