### PR TITLE
Fix: Adiciona limite de números na Pagination para 5

### DIFF
--- a/app/eleicao/templates/eleicao/plugins/candidate_list.html
+++ b/app/eleicao/templates/eleicao/plugins/candidate_list.html
@@ -18,23 +18,25 @@
             </div>
 
             {% if is_paginated %}
-            <ul class="flex gap-2 py-6 mx-auto text-xl font-bold text-center">
-                {% if page_obj.has_previous %}
-                <li><a href="?page={{ page_obj.previous_page_number }}{% if filter_state %}&uf={{filter_state}}{% endif %}">&laquo;</a></li>
-                {% else %}
-                <li class="disabled"><span>&laquo;</span></li>
+            <ul class="flex py-6 mx-auto text-xl font-bold text-center join">
+              {% if page_obj.has_previous %}
+                  <li><a href="?page={{ page_obj.previous_page_number }}{% if filter_state %}&uf={{filter_state}}{% endif %}" class="join-item btn">&laquo;</a></li>
+              {% else %}
+                  <li class="join-item btn btn-disabled"><span>&laquo;</span></li>
+              {% endif %}
+
+              {% for page_num in paginator.page_range %}
+                {% if page_obj.number == page_num %}
+                  <li><button class="join-item btn btn-md btn-active">{{ page_num }} </button></li>
+                {% elif page_num >= page_obj.number|add:"-2" and page_num <= page_obj.number|add:"2" %}
+                  <li><a href="?page={{ page_num }}{% if filter_state %}&uf={{filter_state}}{% endif %}" class="join-item btn btn-md">{{ page_num }}</a></li>
                 {% endif %}
-                {% for i in paginator.page_range %}
-                {% if page_obj.number == i %}
-                    <li class="underline"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                {% else %}
-                    <li><a href="?page={{ i }}{% if filter_state %}&uf={{filter_state}}{% endif %}">{{ i }}</a></li>
-                {% endif %}
-                {% endfor %}
+              {% endfor %}
+
                 {% if page_obj.has_next %}
-                <li><a href="?page={{ page_obj.next_page_number }}{% if filter_state %}&uf={{filter_state}}{% endif %}">&raquo;</a></li>
+                    <li><a href="?page={{ page_obj.next_page_number }}{% if filter_state %}&uf={{filter_state}}{% endif %}" class="join-item btn">&raquo;</a></li>
                 {% else %}
-                <li class="disabled"><span>&raquo;</span></li>
+                    <li class="join-item btn btn-disabled"><span>&raquo;</span></li>
                 {% endif %}
             </ul>
             {% endif %}


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
A interface da paginação estava mostrando todos os números para escolha da pagina acessada pela pessoa user. Esse PR limita esses números para mostrar apenas 5 números na paginação.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205432748829671/f

### Requisitos
- [x] Adiciona limite de números na Pagination para 5
- [x] Adiciona DaisyUI a paginação (pra ficar bonitin)

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/112a1c1e-f514-4060-84a6-67405b7fbe39)
