### PR TITLE
Fix: Adiciona VoterForm na templatetag para refatorar filtros de Estado e Cidade

### DIFF
--- a/app/eleicao/cms_plugins.py
+++ b/app/eleicao/cms_plugins.py
@@ -89,8 +89,6 @@ class EleicaoVoterFormPlugin(CMSPluginBase):
         ctx = super().render(context, instance, placeholder)
         request = ctx.get("request")
 
-        ctx["form"] = VoterForm()
-
         if request.method == "POST":
             form = VoterForm(data=request.POST)
 
@@ -115,6 +113,9 @@ class EleicaoVoterFormPlugin(CMSPluginBase):
                     print("ERROR: Don't create form on Bonde integration!")
                     print(err)
 
-            ctx["form"] = form
+        else:
+            form = VoterForm()
+
+        ctx["form"] = form
 
         return ctx

--- a/app/eleicao/templates/eleicao/plugins/voter_form.html
+++ b/app/eleicao/templates/eleicao/plugins/voter_form.html
@@ -5,7 +5,7 @@
 {% endaddtoblock %}
 
 {% if success %}
-  {% render_candidate_list voter request=request instance=None placeholder=placeholder %}
+  {% render_candidate_list form %}
 {% else %}
   <section class="voter-form">
     <div class="container grid grid-cols-1 gap-16 px-5 py-20 mx-auto md:grid-cols-2">

--- a/app/eleicao/templates/eleicao/plugins/voter_form.html
+++ b/app/eleicao/templates/eleicao/plugins/voter_form.html
@@ -5,13 +5,13 @@
 {% endaddtoblock %}
 
 {% if success %}
-  {% render_candidate_list voter=voter %}
+  {% render_candidate_list voter request=request instance=None placeholder=placeholder %}
 {% else %}
   <section class="voter-form">
-    <div class="container grid grid-cols-1 px-5 py-20 mx-auto md:grid-cols-2 gap-16">
+    <div class="container grid grid-cols-1 gap-16 px-5 py-20 mx-auto md:grid-cols-2">
       <div class="flex flex-col gap-2 items-center pb-6 md:pb-0">
         <img class="pt-8 w-full max-w-[509px] md:pt-16 md:block" src="{% static 'images/eleicao/eleicaodoano-esta-chegando.png' %}" alt="A Eleição do Ano está chegando!">
-        <div class="pt-8 mx-auto text-center text-blue-800 flex flex-col gap-4">
+        <div class="flex flex-col gap-4 pt-8 mx-auto text-center text-blue-800">
           {{ instance.description|linebreaks }}
         </div>
       </div>

--- a/app/eleicao/templatetags/eleicao_candidate_tags.py
+++ b/app/eleicao/templatetags/eleicao_candidate_tags.py
@@ -11,23 +11,24 @@ register = template.Library()
 
 
 @register.inclusion_tag("eleicao/templatetags/candidate_list.html")
-def render_candidate_list(voter: Voter, request=None, instance=None, placeholder=None):
-    form = VoterForm(data=request.POST)
-
+def render_candidate_list(form):
     object_list = None
+    place = form.cleaned_data.get("place")
+    state = form.cleaned_data.get("state")
+    city = form.cleaned_data.get("city")
 
     if form.is_valid():
-        if not voter.place and not voter.city:
+        if not place and not city:
             object_list = Candidate.objects.filter(
-                place__state=form.cleaned_data.get("state")
+                place__state=state
             )
-        elif not voter.place:
+        elif not place:
             object_list = Candidate.objects.filter(
-                place__state=form.cleaned_data.get("state"),
-                place__city=form.cleaned_data.get("city")
+                place__state=state,
+                place__city=city
             )
         else:
-            object_list = Candidate.objects.filter(place=form.cleaned_data.get("place"))
+            object_list = Candidate.objects.filter(place=place)
 
     url = "https://aeleicaodoano.org"
 
@@ -50,5 +51,4 @@ def render_candidate_list(voter: Voter, request=None, instance=None, placeholder
         "msg_twitter": msg_twitter,
         "url_facebook_modal": url_facebook_modal,
         "msg_copy_link": msg_copy_link,
-        "form": form,
     }


### PR DESCRIPTION

### Contexto
Adiciona VoterForm na templatetag para refatorar filtros de Estado e Cidade e considerar apenas os dados inseridos no formulário no momento do envio. 

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205436279271679 

### Requisitos
- [x] Refatora render_candidate_list
- [x] Adiciona validação em `cms_plugins.py` 
- [x] Adiciona form ao update de contexto

### Como testar
- Realize uma busca com Estado e Cidade preenchidos
- Faça uma nova busca sem preencher Cidade e veja se filtra apenas por Estado (já que o o valor de Cidade não deve ser salvo no Eleitor anteriormente).
