### PR TITLE
Fix: Adiciona pontuação em texto de Cadastro de Candidates

### DIFF
--- a/app/eleicao/forms/candidate.py
+++ b/app/eleicao/forms/candidate.py
@@ -63,7 +63,7 @@ class Commitment1Form(forms.Form):
         icon="icon-lgbt",
     )
     agree_5 = IconBooleanField(
-        label="Prioridade ao acionamento da rede de proteção, com encaminhamento a medidas socioeducativas como ultimo recurso",
+        label="Prioridade ao acionamento da rede de proteção, com encaminhamento a medidas socioeducativas como último recurso.",
         required=True,
         icon="icon-network",
     )

--- a/app/eleicao/templates/eleicao/includes/form_control.html
+++ b/app/eleicao/templates/eleicao/includes/form_control.html
@@ -38,7 +38,7 @@
     {% endif %}
   </div>
   {% if field.name == "lgpd" %}
-    <p class="mt-5">Esta escolha não afeta a participação do Candidato na Campanha.</p>
+    <p class="mt-5">Esta escolha não afeta a participação da candidatura na Campanha.</p>
   {% endif %}
 
   {% if field.name == "social_media" %}


### PR DESCRIPTION
### Contexto
Adiciona pontuação em texto de Cadastro de Candidates e utiliza a linguagem neutra no aviso de continuidade do cadastro.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205499372628270/f

### Requisitos
- [x] "[...] como último recurso." (acentuar a palavra 'último' e colocar ponto final)
- [x] "Esta escolha não afeta a participação da candidatura [...]" (trocar candidato por candidatura)
