### PR TITLE
Fix: Adiciona w-full ao GridPlugin

### DIFF
--- a/app/contrib/frontend/grid/templates/frontend/grid/plugins/grid.html
+++ b/app/contrib/frontend/grid/templates/frontend/grid/plugins/grid.html
@@ -1,6 +1,6 @@
 {% load cms_tags %}
 
-<div class="grid gap-20 {{ instance.cols }}">
+<div class="grid gap-20 w-full {{ instance.cols }}">
 {% for plugin in instance.child_plugin_instances %}
     {% render_plugin plugin %}
 {% endfor %}


### PR DESCRIPTION
### Contexto
Adiciona w-full ao GridPlugin para não quebrar ao alterar o texto das colunas.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205679448436925/f

### Requisitos
- [x] Adiciona w-full ao GridPlugin

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/d9f519fa-73fc-43d7-ba10-7ddc1d9f77f9)
