### PR TITLE
Fix: Contador de pessoas que pressionaram

### DIFF
--- a/app/contrib/actions/pressure/cms_plugins.py
+++ b/app/contrib/actions/pressure/cms_plugins.py
@@ -12,6 +12,7 @@ class PressurePlugin(CMSPluginBase):
     render_template = "pressure/pressure_plugin.html"
     model = PressurePluginModel
     form = PressurePluginForm
+    cache = False
 
     def render(self, context, instance, placeholder):
         obj = instance.get_widget()


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
<!-- Qual problema esse PR resolve? -->
Ao preencher o formulário de pressão de recarregar a página o contador não muda.

- Primeiro devemos considerar que o contador considera Ativistas destintos, ou seja se o mesmo Ativista fez 3 pressões, consideramos no calculo a pressão por 1 pessoa.
- Removemos o cache do plugin para evitar que o carregamento do número de pessoas que pressionaram não seja atualizado instataneamente