### PR TITLE
Fix: Adiciona filter e comparação para código + título no Mapa

### DIFF
--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -131,25 +131,32 @@ if (mapWrapper) {
       const api = mapWrapper.dataset.mapsGeojson;
       return new Promise((resolve) => {
         fetch(api)
-          .then((response) => response.json())
-          .then((data) => {
-            const result = data.features
-              .sort((a, b) =>
-                a.properties.title.localeCompare(b.properties.title)
-              )
-              .filter((element) => {
-                return element.properties.title.match(
+        .then((response) => response.json())
+        .then((data) => {
+          const result = data.features
+            .filter((element) => {
+              const lnCodigoMatch = element.properties.ln_codigo.toString().match(
+                new RegExp(currentValue, "gi")
+              );
+              const titleMatch = element.properties.title.match(
                   new RegExp(currentValue, "gi")
-                );
-              });
-            resolve(result);
-          })
-          .catch((error) => console.error(error));
+              );
+              return titleMatch || lnCodigoMatch;
+            })
+            .sort((a, b) => {
+                const aCombination = `${a.properties.ln_codigo} - ${a.properties.title}`;
+                const bCombination = `${b.properties.ln_codigo} - ${b.properties.title}`;
+                
+                return aCombination.localeCompare(bCombination);
+            });
+          resolve(result);
+        })
+        .catch((error) => console.error(error))
       });
     },
 
     onResults: ({ matches, template }) =>
-      matches === 0 ? template : matches.map((el) => `<li><div class="title">${el.properties.title}</div></li>`).join(""),
+      matches === 0 ? template : matches.map((el) => `<li><div class="title">${el.properties.ln_codigo} - ${el.properties.title}</div></li>`).join(""),
 
     onSubmit: ({ object }) => {
       const coordinates = object.geometry.coordinates;


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
Adiciona filter e comparação para código + título no Mapa. Agora as pessoas usuárias podem buscar pelo título ou pelo código da linha no Mapa.


### Requisitos
- [x] Adiciona filter e comparação para código + título no Mapa

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/0bd30f48-a2cc-4199-9591-9789b3a7ba3a)
