### PR TITLE
Fix: Refatora uso de marcadores e linha para adequar as configs de iOS

### DIFF
--- a/app/contrib/frontend/maps/static/maps/css/maps.css
+++ b/app/contrib/frontend/maps/static/maps/css/maps.css
@@ -1,0 +1,3 @@
+.leaflet-pane .leaflet-map-pane {
+  will-change: transform;
+}

--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -1,3 +1,8 @@
+/* eslint-disable no-undef */
+/**
+ * autocomplete with geojson
+ */
+
 let config = {
   minZoom: 7,
   maxZoom: 18,
@@ -11,10 +16,8 @@ const lng = -46.63366;
 const mapWrapper = document.querySelector("#map");
 
 if (mapWrapper) {
-  // Adiciona o mapa
   const map = L.map("map", config).setView([lat, lng], zoom);
 
-  // Carrega e mostra o layer
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     attribution:
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
@@ -36,7 +39,7 @@ if (mapWrapper) {
       container.insertAdjacentHTML(
         "beforeend",
         `<div class="auto-search-wrapper loupe">
-          <input type="text" id="show-all-values" autocomplete="off" placeholder="${searchPlaceholder}" />
+          <input type="text" id="local" autocomplete="off" placeholder="${searchPlaceholder}" />
         </div>`
       );
 
@@ -46,11 +49,10 @@ if (mapWrapper) {
 
   new L.Control.Search().addTo(map);
 
-  let startPoint, endPoint, geojsonLayer, markersGeoJSON;
   let geojsonarray = [];
 
   let popupText = (properties) => {
-    let ifObsProperty = !!properties?.observacoes ? `<span>Obs: ${properties.observacoes}</span><br>` : "";
+    let ifObsProperty = !!properties?.observacoes ? `<span><strong>Obs:</strong> ${properties.observacoes}</span><br>` : "";
 
     return `<span><strong>Número:</strong> ${properties.ln_codigo}</span><br>` +
     `<span><strong>Nome:</strong> ${properties.title}</span><br>` +
@@ -61,60 +63,9 @@ if (mapWrapper) {
     ifObsProperty;
   }
 
-  function addMarkers(coordinates, properties) {
-    let LeafIcon = L.Icon.extend({
-      options: {
-          iconSize:     [40, 40],
-          iconAnchor:   [22, 50],
-          popupAnchor:  [-3, -76]
-      }
-    });
-    
-    // Remove marcadores existentes
-    if (startPoint) map.removeLayer(startPoint);
-    if (endPoint) map.removeLayer(endPoint);
-
-    function createMarker(iconUrl, coordinates) {
-      const icon = iconUrl ? new LeafIcon({ iconUrl }) : null;
-      return L.marker([coordinates[1], coordinates[0]], { icon });
-    }
-
-    startPoint = createMarker(mapWrapper.dataset.mapsIconsPointA, coordinates[0]);
-
-    endPoint = createMarker(mapWrapper.dataset.mapsIconsPointB, coordinates[coordinates.length -1])
 
 
-    [startPoint, endPoint].forEach(marker => {
-      marker.bindPopup(popupText(properties))
-    });
-  }
-
-  function addPolyline(coordinates, properties) {
-    const lineColor = mapWrapper.dataset.mapsLinecolor;
-
-    if (geojsonLayer) map.removeLayer(geojsonLayer);
-
-    geojsonLayer = L.geoJSON({
-      type: "LineString",
-      coordinates: coordinates,
-    }, {
-      style: {
-        color: lineColor || "red",
-        weight: 3,
-        opacity: 1,
-        fillOpacity: 0.5,
-      },
-      onEachFeature: function (feature, layer) {
-        layer.bindPopup(popupText(properties));
-      },
-    })
-  }
-
-  new Autocomplete("show-all-values", {
-    clearButton: true,
-    cache: true,
-    showAllValues: true,
-
+  new Autocomplete("local", {
     onSearch: ({ currentValue }) => {
       const api = mapWrapper.dataset.mapsGeojson;
       return new Promise((resolve) => {
@@ -143,35 +94,88 @@ if (mapWrapper) {
       });
     },
 
-    onResults: ({ matches, template }) =>
-      matches === 0 ? template : matches.map((el) => `<li><div class="title">${el.properties.ln_codigo} - ${el.properties.title}</div></li>`).join(""),
+    onResults: ({ matches, template }) => {
+      return matches === 0
+        ? template
+        : matches
+            .map((el) => {
+              return `
+                <li>
+                  <div class="title">${el.properties.ln_codigo} - ${el.properties.title}</div>
+                </li>`;
+            })
+            .join("");
+    },
 
     onSubmit: ({ object }) => {
-      console.log("maps on submit", object)
-      const coordinates = object.geometry.coordinates;
       const properties = object.properties;
+      const coordinates = object.geometry.coordinates;
+      const lineColor = mapWrapper.dataset.mapsLinecolor;
 
-      addPolyline(coordinates, properties);
+      const geojsonlayer = L.geoJSON(object, {
+        style: function (feature) {
+          return {
+            color: lineColor || "red",
+            weight: 7,
+            opacity: 1,
+            fillOpacity: 0.7,
+          };
+        },
+        onEachFeature: function (feature, layer) {
+          layer.bindPopup(popupText(properties));
+        },
+      });
 
-      map.fitBounds(geojsonLayer.getBounds(), { padding: [150, 150] });
+      const geojsonmarkers = (properties, coordinates) => {
+
+        let LeafIcon = L.Icon.extend({
+          options: {
+              iconSize:     [40, 40],
+              iconAnchor:   [22, 50],
+              popupAnchor:  [-3, -76]
+          }
+        });
+
+        if (mapWrapper.dataset.mapsIconsPointA) {
+          const startIcon = new LeafIcon({ iconUrl: mapWrapper.dataset.mapsIconsPointA });
+          startPoint = L.marker([coordinates[0][1], coordinates[0][0]], { icon: startIcon }).addTo(map);
+        } else {
+          startPoint = L.marker([coordinates[0][1], coordinates[0][0]]).addTo(map);
+        }
+        
+        if (mapWrapper.dataset.mapsIconsPointB) {
+          const endIcon = new LeafIcon({ iconUrl: mapWrapper.dataset.mapsIconsPointB }).addTo(map);
+          endPoint = L.marker([coordinates[coordinates.length - 1][1], coordinates[coordinates.length - 1][0]], { icon: endIcon }).addTo(map);
+        } else {
+          endPoint = L.marker([coordinates[coordinates.length - 1][1], coordinates[coordinates.length - 1][0]]).addTo(map);
+        }
+
+        [startPoint, endPoint].forEach(marker => {
+          marker.bindPopup(popupText(properties))
+        });
+      }
+
+      map.fitBounds(geojsonlayer.getBounds(), { padding: [150, 150] });
 
       if (geojsonarray.includes(object.properties.id)) return;
       geojsonarray.push(object.properties.id);
 
-      geojsonLayer.addTo(map);
-      // startPoint.addTo(map);
-      // endPoint.addTo(map);
+
+      geojsonmarkers(properties, coordinates);
+      geojsonlayer.addTo(map);
     },
 
-    noResults: ({ currentValue, template }) => template(`<li>Sem resultados: "${currentValue}"</li>`),
+    noResults: ({ currentValue, template }) =>
+      template(`<li>Sem resultados: "${currentValue}"</li>`),
 
     onReset: () => {
-      // Remove marcadores e linha
-      [startPoint, endPoint, geojsonLayer].forEach(layer => {
-        if (layer) map.removeLayer(layer);
+      // remove all layers
+      map.eachLayer(function (layer) {
+        if (!!layer.toGeoJSON) {
+          map.removeLayer(layer);
+        }
       });
-
       geojsonarray = [];
     },
-  }); 
+  });
 }

--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -159,6 +159,7 @@ if (mapWrapper) {
       matches === 0 ? template : matches.map((el) => `<li><div class="title">${el.properties.ln_codigo} - ${el.properties.title}</div></li>`).join(""),
 
     onSubmit: ({ object }) => {
+      console.log("maps on submit", object)
       const coordinates = object.geometry.coordinates;
       const properties = object.properties;
 

--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -63,8 +63,6 @@ if (mapWrapper) {
     ifObsProperty;
   }
 
-
-
   new Autocomplete("local", {
     onSearch: ({ currentValue }) => {
       const api = mapWrapper.dataset.mapsGeojson;
@@ -127,7 +125,6 @@ if (mapWrapper) {
       });
 
       const geojsonmarkers = (properties, coordinates) => {
-
         let LeafIcon = L.Icon.extend({
           options: {
               iconSize:     [40, 40],
@@ -160,7 +157,6 @@ if (mapWrapper) {
       if (geojsonarray.includes(object.properties.id)) return;
       geojsonarray.push(object.properties.id);
 
-
       geojsonmarkers(properties, coordinates);
       geojsonlayer.addTo(map);
     },
@@ -169,7 +165,6 @@ if (mapWrapper) {
       template(`<li>Sem resultados: "${currentValue}"</li>`),
 
     onReset: () => {
-      // remove all layers
       map.eachLayer(function (layer) {
         if (!!layer.toGeoJSON) {
           map.removeLayer(layer);

--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -2,8 +2,6 @@ let config = {
   minZoom: 7,
   maxZoom: 18,
   zoomControl: false,
-  autoPan: false,
-  scrollWheelZoom: false
 };
 
 const zoom = 18;

--- a/app/contrib/frontend/maps/static/maps/js/maps.js
+++ b/app/contrib/frontend/maps/static/maps/js/maps.js
@@ -7,6 +7,9 @@ let config = {
   minZoom: 7,
   maxZoom: 18,
   zoomControl: false,
+  scrollWheelZoom: false,
+  dragging: false,
+  tap: false
 };
 
 const zoom = 18;
@@ -134,15 +137,15 @@ if (mapWrapper) {
         });
 
         if (mapWrapper.dataset.mapsIconsPointA) {
-          const startIcon = new LeafIcon({ iconUrl: mapWrapper.dataset.mapsIconsPointA });
-          startPoint = L.marker([coordinates[0][1], coordinates[0][0]], { icon: startIcon }).addTo(map);
+          let startIcon = new LeafIcon({iconUrl: mapWrapper.dataset.mapsIconsPointA})
+          startPoint = L.marker([coordinates[0][1], coordinates[0][0]], {icon: startIcon}).addTo(map);
         } else {
           startPoint = L.marker([coordinates[0][1], coordinates[0][0]]).addTo(map);
         }
-        
+
         if (mapWrapper.dataset.mapsIconsPointB) {
-          const endIcon = new LeafIcon({ iconUrl: mapWrapper.dataset.mapsIconsPointB }).addTo(map);
-          endPoint = L.marker([coordinates[coordinates.length - 1][1], coordinates[coordinates.length - 1][0]], { icon: endIcon }).addTo(map);
+          let endIcon = new LeafIcon({iconUrl: mapWrapper.dataset.mapsIconsPointB})
+          endPoint = L.marker([coordinates[coordinates.length - 1][1], coordinates[coordinates.length - 1][0]], {icon: endIcon}).addTo(map);
         } else {
           endPoint = L.marker([coordinates[coordinates.length - 1][1], coordinates[coordinates.length - 1][0]]).addTo(map);
         }


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
Conforme citado pela Clareana e pela @sarahsoaresc, o Mapa não estava funcionando em iOS (Safari, Chrome). Esse PR refatora o fluxo de adição da linha e marcadores no Mapa seguindo o exemplo encontrado [aqui](https://tomickigrzegorz.github.io/leaflet-examples/#). Também foi desabilitado o uso de scroll ou touch para navegar no mapa, impossibilitando as pessoas usuárias de ficarem presas ao mapa. Os controles de zoom serão a única opção de navegar dentro do mapa.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1205798683607082/f

### Requisitos
- [x] Refatora uso da criação de marcadores e linha no Mapa

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/f31d68a8-4703-4071-bc5d-bae6227c17c3)
