### PR TITLE
BugFix: Sobreescreve a propriedade CSS visibility de Fieldset para uset

### DIFF
--- a/app/admin_styled/static/admin_styled/css/theme.css
+++ b/app/admin_styled/static/admin_styled/css/theme.css
@@ -5,3 +5,7 @@
 .cms-pagetree-header-search .cms-pagetree-header-search-btn:hover {
     background-color: var(--dca-primary) !important;
 }
+
+form fieldset.collapse { 
+    visibility: unset;
+}


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
Tive que sobreescrever a propriedade CSS `visibility: collapse` de todos os fieldsets para `unset` para que o JavaScript herdado do módulo oficial do Django possa funcionar. Obs: ou seja, tanto o link no ImagePlugin e o crop também já estavam implementados, eles só não estavam aparecendo no form por causa desse bug.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1206174894482096/f

### Requisitos
- [x] Testar cenários onde o fieldset é utilizado ao adicionar um Plugin no CMS
- [x] Sobreescrever a propriedade CSS visibility de Fieldset para uset
<!-- Descreva as mudanças principais do PR -->

### Screenshots
![image](https://github.com/nossas/cms/assets/121839261/b5f9024a-247c-406b-af17-67204829f775)
