### PR TITLE
Feature: Adiciona HeaderPlugin

### DIFF
--- a/app/nossas/plugins/cms_plugins/__init__.py
+++ b/app/nossas/plugins/cms_plugins/__init__.py
@@ -7,5 +7,6 @@ from .container import *
 from .footer import *
 from .gallery import *
 from .grid import *
+from .header import *
 from .navbar import *
 from .slider import *

--- a/app/nossas/plugins/cms_plugins/box.py
+++ b/app/nossas/plugins/cms_plugins/box.py
@@ -56,60 +56,6 @@ class BoxPlugin(UICMSPluginBase):
 
         return super().get_fieldsets(request, obj)
 
-    def create_header_box(self, obj):
-        placeholder = obj.placeholder
-        language = obj.language
-
-        # Child plugins
-
-        # Add Image inside Box
-        plugin_type = "PicturePlugin"
-        child_attrs = {
-            # Define fake image
-            "external_picture": "http://via.placeholder.com/640x360",
-            "template": "background",
-            "height": 360,
-        }
-        add_plugin(
-            placeholder=placeholder,
-            plugin_type=plugin_type,
-            language=language,
-            target=obj,
-            **child_attrs,
-        )
-
-        # Add Box inside Box
-        plugin_type = "BoxPlugin"
-        child_attrs = {
-            "attributes": {
-                "padding": [
-                    {"side": "t", "spacing": "3"},
-                    {"side": "b", "spacing": "4"},
-                    {"side": "x", "spacing": "5"},
-                ]
-            }
-        }
-        obj = add_plugin(
-            placeholder=placeholder,
-            plugin_type=plugin_type,
-            language=language,
-            target=obj,
-            **child_attrs,
-        )
-
-        # Add Text inside new Box
-        plugin_type = "TextPlugin"
-        child_attrs = {
-            "body": """<h1>Lorem ipsum</h1><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ut enim ad minim veniam, quis nostrud exercitation.</p>"""
-        }
-        add_plugin(
-            placeholder=placeholder,
-            plugin_type=plugin_type,
-            language=language,
-            target=obj,
-            **child_attrs,
-        )
-
     def create_cta_box(self, obj):
         placeholder = obj.placeholder
         language = obj.language

--- a/app/nossas/plugins/cms_plugins/container.py
+++ b/app/nossas/plugins/cms_plugins/container.py
@@ -26,7 +26,6 @@ class ContainerPlugin(UICMSPluginBase):
     def get_fieldsets(self, request, obj=None):
         if not obj:
             self.fieldsets = (
-                (None, {"fields": ["attributes", "layout"]}),
                 ("Fundo", {"fields": ["background"]}),
                 ("Espaçamento", {"fields": [("padding")]}),
                 (

--- a/app/nossas/plugins/cms_plugins/header.py
+++ b/app/nossas/plugins/cms_plugins/header.py
@@ -1,0 +1,90 @@
+from cms.api import add_plugin
+
+from cms.plugin_pool import plugin_pool
+
+from nossas.design.cms_plugins import UICMSPluginBase
+
+from nossas.plugins.models.headermodel import Header
+from nossas.plugins.forms.headerform import HeaderPluginForm
+
+@plugin_pool.register_plugin
+class HeaderPlugin(UICMSPluginBase):
+    name = "Header"
+    module = "NOSSAS"
+    model = Header
+    form = HeaderPluginForm
+    render_template = "nossas/plugins/header.html"
+    allow_children = True
+    fieldsets = (
+        ("Atributos", {"fields": ["attributes"]}),
+        ("Fundo", {"fields": ["background"]})
+    )
+
+    def get_form(self, request, obj, change, **kwargs):
+        if not change:
+            self.form = HeaderPluginForm
+
+        return super().get_form(request, obj, change, **kwargs)
+
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            self.fieldsets = (
+                (None, {"fields": ["attributes"]}),
+                ("Fundo", {"fields": ["background"]}),
+            )
+
+        return super().get_fieldsets(request, obj)
+
+    def create_header_box(self, obj):
+        placeholder = obj.placeholder
+        language = obj.language
+
+        # Child plugins
+
+        # Add Image inside Box
+        plugin_type = "PicturePlugin"
+        child_attrs = {
+            # Define fake image
+            "external_picture": "http://via.placeholder.com/640x360",
+            "template": "background",
+            "height": 360,
+        }
+        add_plugin(
+            placeholder=placeholder,
+            plugin_type=plugin_type,
+            language=language,
+            target=obj,
+            **child_attrs,
+        )
+
+        # Add Box inside Box
+        plugin_type = "BoxPlugin"
+        child_attrs = {
+            "attributes": {
+                "padding": [
+                    {"side": "t", "spacing": "3"},
+                    {"side": "b", "spacing": "4"},
+                    {"side": "x", "spacing": "5"},
+                ]
+            }
+        }
+        obj = add_plugin(
+            placeholder=placeholder,
+            plugin_type=plugin_type,
+            language=language,
+            target=obj,
+            **child_attrs,
+        )
+
+        # Add Text inside new Box
+        plugin_type = "TextPlugin"
+        child_attrs = {
+            "body": """<h1>Lorem ipsum</h1><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ut enim ad minim veniam, quis nostrud exercitation.</p>"""
+        }
+        add_plugin(
+            placeholder=placeholder,
+            plugin_type=plugin_type,
+            language=language,
+            target=obj,
+            **child_attrs,
+        )

--- a/app/nossas/plugins/forms/headerform.py
+++ b/app/nossas/plugins/forms/headerform.py
@@ -1,0 +1,15 @@
+from django import forms
+
+from nossas.design.forms import ( 
+    UIBackgroundFormMixin
+)
+
+from nossas.plugins.models.headermodel import Header
+
+
+class HeaderPluginForm(
+     UIBackgroundFormMixin, forms.ModelForm
+):
+    class Meta:
+        model = Header
+        entangled_fields = {"attributes": []}

--- a/app/nossas/plugins/models/__init__.py
+++ b/app/nossas/plugins/models/__init__.py
@@ -3,5 +3,6 @@ from .boxmodel import *
 from .buttonmodel import *
 from .containermodel import *
 from .gridmodel import *
+from .headermodel import *
 from .navbarmodel import *
 from .slidermodel import *

--- a/app/nossas/plugins/models/headermodel.py
+++ b/app/nossas/plugins/models/headermodel.py
@@ -1,0 +1,5 @@
+from nossas.design.models import UICMSPlugin, UIBackgroundMixin
+
+
+class Header(UIBackgroundMixin, UICMSPlugin):
+    pass

--- a/app/nossas/plugins/templates/nossas/plugins/header.html
+++ b/app/nossas/plugins/templates/nossas/plugins/header.html
@@ -1,14 +1,22 @@
 {% load cms_tags %}
 
 <header class="{{ instance.classes}}">
-    <div class="grid cms-plugin cms-plugin-14" style="row-gap: 0;">
+    <div class="grid">
         <div class="header-row-order d-flex flex-column" style="gap: 0; align-items: end; justify-content: flex-end; ">
             {% for plugin in instance.child_plugin_instances %}
-                {% render_plugin plugin %}
+                {% if plugin.plugin_type == 'BoxPlugin' %}
+                    {% render_plugin plugin %}
+                {% endif %}
             {% endfor %}
         </div>
         <div class="d-flex flex-column header-background-col" style="gap: 0; align-items: start; justify-content: flex-start;">
-            <div style="background-image: url('/media/filer_public_thumbnails/filer_public/04/6d/046ddeea-02b7-4dab-84f1-8027124faf13/vector1.svg__683x360.svg');" title="" class="header-background-img"></div>
+            {% for plugin in instance.child_plugin_instances %}
+                {% if plugin.plugin_type == 'PicturePlugin' %}
+                    {% for url in picture_urls %}
+                        <div class="header-background-img" style="background-image: url('{{ url }}');"></div>
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
         </div>
     </div>
 </header>
@@ -25,10 +33,14 @@
         }
 
         .header-background-img {
+            width: 100%;
+        }
+
+        .header-background-img {
             background-repeat: no-repeat;
             background-size: 100% 100%;
             width: 100%;
-            height: 250px;
+            height: 275px;
             background-position-x: center;
         }
 

--- a/app/nossas/plugins/templates/nossas/plugins/header.html
+++ b/app/nossas/plugins/templates/nossas/plugins/header.html
@@ -1,0 +1,16 @@
+{% load cms_tags %}
+
+<header class="{{ instance.classes}}">
+  <div class="container">
+        <div class="grid cms-plugin cms-plugin-14" style="row-gap: 0;">
+            <div class="d-flex flex-column g-col-4     cms-plugin cms-plugin-15" style="gap: 0; align-items: end; justify-content: flex-end;  ">
+                {% for plugin in instance.child_plugin_instances %}
+                    {% render_plugin plugin %}
+                {% endfor %}
+            </div>
+            <div class="d-flex flex-column g-col-8     cms-plugin cms-plugin-16" style="gap: 0; align-items: start; justify-content: flex-start;  ">
+                <div style="background-image: url('/media/filer_public_thumbnails/filer_public/04/6d/046ddeea-02b7-4dab-84f1-8027124faf13/vector1.svg__683x360.svg');background-repeat:no-repeat;background-size:100% 100%;width:100%;height:360px;" title="" class="cms-plugin cms-plugin-20"></div>
+            </div>
+        </div>
+    </div>
+</header>

--- a/app/nossas/plugins/templates/nossas/plugins/header.html
+++ b/app/nossas/plugins/templates/nossas/plugins/header.html
@@ -1,16 +1,64 @@
 {% load cms_tags %}
 
 <header class="{{ instance.classes}}">
-  <div class="container">
-        <div class="grid cms-plugin cms-plugin-14" style="row-gap: 0;">
-            <div class="d-flex flex-column g-col-4     cms-plugin cms-plugin-15" style="gap: 0; align-items: end; justify-content: flex-end;  ">
-                {% for plugin in instance.child_plugin_instances %}
-                    {% render_plugin plugin %}
-                {% endfor %}
-            </div>
-            <div class="d-flex flex-column g-col-8     cms-plugin cms-plugin-16" style="gap: 0; align-items: start; justify-content: flex-start;  ">
-                <div style="background-image: url('/media/filer_public_thumbnails/filer_public/04/6d/046ddeea-02b7-4dab-84f1-8027124faf13/vector1.svg__683x360.svg');background-repeat:no-repeat;background-size:100% 100%;width:100%;height:360px;" title="" class="cms-plugin cms-plugin-20"></div>
-            </div>
+    <div class="grid cms-plugin cms-plugin-14" style="row-gap: 0;">
+        <div class="header-row-order d-flex flex-column" style="gap: 0; align-items: end; justify-content: flex-end; ">
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+        </div>
+        <div class="d-flex flex-column header-background-col" style="gap: 0; align-items: start; justify-content: flex-start;">
+            <div style="background-image: url('/media/filer_public_thumbnails/filer_public/04/6d/046ddeea-02b7-4dab-84f1-8027124faf13/vector1.svg__683x360.svg');" title="" class="header-background-img"></div>
         </div>
     </div>
 </header>
+
+{% block extrastyle %}
+    <style>
+        .header-row-order {
+            grid-row: 2;
+            grid-column: auto/span 12;
+        }
+
+        .header-background-col {
+            grid-column: auto/span 12;
+        }
+
+        .header-background-img {
+            background-repeat: no-repeat;
+            background-size: 100% 100%;
+            width: 100%;
+            height: 250px;
+            background-position-x: center;
+        }
+
+        @media (min-width: 768px) {
+            .header-row-order {
+                grid-row: 1;
+                grid-column: auto/span 4;
+            }
+
+            .header-background-col {
+                grid-column: auto/span 8;
+            }
+
+            .header-background-img {
+                background-repeat: no-repeat;
+                background-size: 80% 100%;
+                width: 100%;
+                height: 486px;
+                background-position-x: right;
+            }
+        }
+
+        @media (min-width: 992px) {
+            .header-row-order {
+                grid-column: 3/span 3;
+            }
+
+            .header-background-col {
+                grid-column: auto/span 7;
+            }
+        }
+    </style>
+{% endblock %}

--- a/app/nossas/plugins/templates/nossas/plugins/header.html
+++ b/app/nossas/plugins/templates/nossas/plugins/header.html
@@ -2,14 +2,14 @@
 
 <header class="{{ instance.classes}}">
     <div class="grid">
-        <div class="header-row-order d-flex flex-column" style="gap: 0; align-items: end; justify-content: flex-end; ">
+        <div class="d-flex flex-column header-box-col">
             {% for plugin in instance.child_plugin_instances %}
                 {% if plugin.plugin_type == 'BoxPlugin' %}
                     {% render_plugin plugin %}
                 {% endif %}
             {% endfor %}
         </div>
-        <div class="d-flex flex-column header-background-col" style="gap: 0; align-items: start; justify-content: flex-start;">
+        <div class="header-background-col">
             {% for plugin in instance.child_plugin_instances %}
                 {% if plugin.plugin_type == 'PicturePlugin' %}
                     {% for url in picture_urls %}
@@ -23,13 +23,17 @@
 
 {% block extrastyle %}
     <style>
-        .header-row-order {
-            grid-row: 2;
+        .header-box-col {
+            align-items: end;
             grid-column: auto/span 12;
+            grid-row: 2;
+            justify-content: flex-end; 
+            padding: 0 12px;
         }
 
         .header-background-col {
             grid-column: auto/span 12;
+            margin-top: 60px;
         }
 
         .header-background-img {
@@ -37,39 +41,39 @@
         }
 
         .header-background-img {
+            background-position-x: center;
             background-repeat: no-repeat;
             background-size: 100% 100%;
-            width: 100%;
             height: 275px;
-            background-position-x: center;
+            width: 100%;
         }
 
         @media (min-width: 768px) {
-            .header-row-order {
+            .header-box-col {
+                grid-column: auto/span 5;
                 grid-row: 1;
-                grid-column: auto/span 4;
-            }
-
-            .header-background-col {
-                grid-column: auto/span 8;
-            }
-
-            .header-background-img {
-                background-repeat: no-repeat;
-                background-size: 80% 100%;
-                width: 100%;
-                height: 486px;
-                background-position-x: right;
-            }
-        }
-
-        @media (min-width: 992px) {
-            .header-row-order {
-                grid-column: 3/span 3;
             }
 
             .header-background-col {
                 grid-column: auto/span 7;
+            }
+        }
+
+        @media (min-width: 992px) {
+            .header-box-col {
+                grid-column: 3/span 3;
+                padding: 0;
+            }
+
+            .header-background-img {
+                background-position-x: right;
+                background-size: 80% 100%;
+                height: 490px;
+            }
+
+            .header-background-col {
+                grid-column: auto/span 7;
+                margin-top: 0;
             }
         }
     </style>

--- a/app/nossas/settings.py
+++ b/app/nossas/settings.py
@@ -97,6 +97,7 @@ CMS_PLACEHOLDER_CONF = {
             "CampaignListPlugin",
             "ContainerPlugin",
             "GalleryPlugin",
+            "HeaderPlugin",
             "PicturePlugin",
             "SliderJobsPlugin",
             "SliderPlugin",


### PR DESCRIPTION

### Contexto
Adiciona `Header` como plugin. Tive que adicionar três classes no CSS para que houvesse responsividade esperada a partir do que tá no Figma. 

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1206385429210501/f

### Requisitos
- [x] Adiciona Header como plugin

### Screenshots
![Screen Shot 2024-01-22 at 20 05 44](https://github.com/nossas/cms/assets/121839261/33b00a9d-182f-425b-b3c9-1921c984c03d)
![Screen Shot 2024-01-22 at 20 05 51](https://github.com/nossas/cms/assets/121839261/c54176d2-08bd-495f-990e-e7f78f4b2fe6)
![Screen Shot 2024-01-22 at 20 05 56](https://github.com/nossas/cms/assets/121839261/2589f13b-ea1e-4367-bc48-224c77a2011d)


### Layout
https://www.figma.com/file/9aUCKe2Jt8twPVpd47Vffe/NOSSAS_layout_desktop_v2_elementos-coloridos_ajustes?type=design&node-id=25-14665&mode=dev

## Como testar?
- Vá para uma página e adicione `Header` nos plugins
- Adicione uma cor de fundo
- Mude a imagem padrão para a fundo escolhido a partir do Figma
- Altere o texto de acordo com a preferencia
- Teste o cenário mobile > tablet > desktop
