### PR TITLE
[Feature] Habilitar customizações no `djangocms_form_builder`

### DIFF
--- a/app/adp/settings/base.py
+++ b/app/adp/settings/base.py
@@ -90,3 +90,12 @@ CMS_TEMPLATES = [
 ]
 
 CMS_PLACEHOLDER_CONF = {}
+
+# DjangoCMS Form Builder Submodule
+
+DJANGOCMS_FORMS_REQUIRED_CSS_CLASS = "required"
+
+DJANGOCMS_FORMS_FORM_PLUGIN_CHILD_CLASSES = [
+    "BlockPlugin",
+    "ButtonPlugin",
+]

--- a/app/contrib/bonde/cms_plugins.py
+++ b/app/contrib/bonde/cms_plugins.py
@@ -17,9 +17,6 @@ plugin_pool.unregister_plugin(FormPluginBase)
 
 
 class FormsForm(FormsFormBase):
-    submit_text = forms.CharField(
-        label=_("Botão enviar"), required=False, initial=_("Enviar")
-    )
     success_message = HTMLFormField(label=_("Mensagem de sucesso"))
 
     class Meta:
@@ -40,7 +37,7 @@ class FormsForm(FormsFormBase):
         ]
         entangled_fields = {
             "action_parameters": [],
-            "extra_config": ["submit_text", "success_message"],
+            "extra_config": ["success_message"],
         }
 
     def __init__(self, *args, **kwargs):
@@ -60,7 +57,6 @@ class FormPlugin(FormPluginBase):
                 "fields": [
                     "form_selection",
                     "form_name",
-                    "submit_text",
                     "success_message",
                 ],
             },

--- a/app/contrib/bonde/models.py
+++ b/app/contrib/bonde/models.py
@@ -355,10 +355,5 @@ class FormProxy(Form):
         app_label = "djangocms_form_builder"
 
     @property
-    def form_submit_message(self):
-        if "submit_text" in self.extra_config:
-            return self.extra_config.get("submit_text")
-
-    @property
     def render_success(self):
         return "forms/success.html"

--- a/app/contrib/ds/link/cms_plugins.py
+++ b/app/contrib/ds/link/cms_plugins.py
@@ -2,7 +2,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from .forms import ButtonForm
-from .models import Button
+from .models import Button, Target
 
 
 @plugin_pool.register_plugin
@@ -10,7 +10,6 @@ class ButtonPlugin(CMSPluginBase):
     name = "Botão"
     model = Button
     form = ButtonForm
-    render_template = "link/plugins/button.html"
     change_form_template = "link/admin/plugin/change_form.html"
     fieldsets = (
         (
@@ -32,6 +31,12 @@ class ButtonPlugin(CMSPluginBase):
             },
         ),
     )
+
+    def get_render_template(self, context, instance, placeholder):
+        if instance.link_target == Target.submit:
+            return "link/plugins/submit.html"
+
+        return "link/plugins/button.html"
 
     def render(self, context, instance, placeholder):
         css_classes = ["btn"]

--- a/app/contrib/ds/link/models.py
+++ b/app/contrib/ds/link/models.py
@@ -20,6 +20,7 @@ class Context(models.TextChoices):
 class Target(models.TextChoices):
     _self = "_self", _("Abrir na mesma aba")
     _blank = "_blank", _("Abrir em nova aba")
+    submit = "submit", _("Enviar formulário")
 
 
 class Styled(models.TextChoices):

--- a/app/contrib/ds/link/templates/link/admin/plugin/change_form.html
+++ b/app/contrib/ds/link/templates/link/admin/plugin/change_form.html
@@ -65,6 +65,14 @@
             </label>
           </div>
           {% endwith %}
+          {% with choice=field.field.choices.2 %}
+          <div class="radio">
+            <input type="radio" id="{{field.name}}_{{choice.0}}" name="{{field.name}}" value="{{choice.0}}"{% if field.value == choice.0 %} checked{% endif %} />
+            <label for="{{field.name}}_{{choice.0}}">
+              {{ choice.1 }} {% include "blocks/plugin/tooltip.html" with message="Usado em formulários para enviar os dados preenchidos" direction="right" %}
+            </label>
+          </div>
+          {% endwith %}
         </div>
         {{ field.errors }}
       </div>

--- a/app/contrib/ds/link/templates/link/plugins/submit.html
+++ b/app/contrib/ds/link/templates/link/plugins/submit.html
@@ -1,0 +1,3 @@
+<button class="{{css_classes}}" type="submit">
+    {% if instance.icon and instance.icon_position == 'left' %}<i class='bi bi-{{instance.icon}}'></i> {% endif %}{{instance.label}}{% if instance.icon and instance.icon_position == 'right' %} <i class='bi bi-{{instance.icon}}'></i>{% endif %}
+</button>

--- a/app/contrib/ds/link/tests.py
+++ b/app/contrib/ds/link/tests.py
@@ -259,6 +259,25 @@ class LinkPluginsTestCase(CMSTestCase):
         )
 
         self.assertHTMLEqual(html, expected_html)
+    
+    def test_render_submit_button(self):
+        plugin = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type="ButtonPlugin",
+            language=self.language,
+            label="Enviar",
+            link_target=Target.submit
+        )
+        plugin.full_clean()
+
+        renderer = ContentRenderer(request=RequestFactory())
+
+        html = renderer.render_plugin(plugin, {})
+        expected_html = (
+            f"<button class='btn btn-primary' type='submit'>Enviar</button>"
+        )
+
+        self.assertHTMLEqual(html, expected_html)
 
 
 # <i class="bi bi-map-fill"></i>

--- a/app/contrib/ds/static/ds/css/forms.scss
+++ b/app/contrib/ds/static/ds/css/forms.scss
@@ -1,0 +1,10 @@
+label {
+    color: $dark;
+    font-weight: 800;
+    font-size: $font-size-sm;
+}
+
+label.required::after {
+    content: ' *';
+    color: $danger;
+}

--- a/app/contrib/ds/static/ds/css/theme.scss
+++ b/app/contrib/ds/static/ds/css/theme.scss
@@ -45,3 +45,5 @@ img {
 #cms-top + nav.fixed-top {
   margin-top: 46px;
 }
+
+@import "./forms.scss";


### PR DESCRIPTION
<!-- IMPORTANTE: Confira o arquivo CONTRIBUTING.md para detalhes de como contribuir seguindo o guia e remova os tópicos que não forem utilizados nesse template. -->

### Contexto
<!-- Qual problema esse PR resolve? -->
O plugin de Formulário é um fork de uma biblioteca chamada [djangocms_form_builder](https://github.com/nossas/djangocms-form-builder/tree/feature/add-input-fields-on-form-plugin). Ela faz estilização com base no Bootstrap5, apesar de ser uma biblioteca com boas funcionalidades, fazer uma customização não é tão simples.

O objetivo é tornar possível configurar novos plugins dentro do Formulário, adicionando liberdade para montar a estrutura do formulário.

### Link da Tarefa/Issue
- [x] https://app.asana.com/0/1161468210277385/1207221022724568/f
<!-- Adicione as respectivas issues/tarefas relacionadas a esse PR -->

### Requisitos
- [x] Adicionar plugin de Bloco e Botão dentro de um Formulário
- [x] Criar plugin de Botão para submeter formulário
<!-- Descreva as mudanças principais do PR -->

### Screenshots
<!-- Adicione algumas imagens para ter um preview da sua tarefa, para ajudar devs e designer a entender o que anda sendo trabalhado nesse PR -->

![image](https://github.com/nossas/cms/assets/2062174/1685b833-c160-409e-af2b-a0016b9b3647)

![image](https://github.com/nossas/cms/assets/2062174/ba51f85b-e341-4168-b4a3-e2c8abadc7c6)

## Como testar?
<!-- Descreva passo a passo como testar seu PR -->
- Inserir um plugin de `Formulário`
- Inserir um plugin de `Bloco` dentro desse `Formulário`
- Inserir um plugin de `Campo Texto` dentro do `Bloco`
- Inserir um plugin de `Botão` com **Comportamento do link** de **Enviar o formulário** dentro do `Formulário`

## Notas de Deploy
<!-- Quais dependencias, scripts, etc foram adicionados a esse PR? Insira tudo que for útil para o Deploy -->
- Utiliza nova versão do `djangocms_form_builder` que precisa ser buildada

## BREAKING CHANGES
- Essa versão remove o botão de submissão do Formulário que era inserido direto no template HTML do plugin