### PR TITLE
fix(votepeloclima): Fixed add input script

### DIFF
--- a/app/org_eleicoes/votepeloclima/candidature/fields.py
+++ b/app/org_eleicoes/votepeloclima/candidature/fields.py
@@ -250,9 +250,10 @@ class CheckboxTextField(forms.CharField):
 class InlineArrayWidget(forms.MultiWidget):
     template_name = "forms/widgets/inline_array.html"
 
-    def __init__(self, widget, size, item_label=None, add_button_text=None, attrs=None):
+    def __init__(self, widget, size, item_label=None, add_button_text=None, placeholder=None, attrs=None):
         self.add_button_text = add_button_text
         self.item_label = item_label
+        self.placeholder = placeholder or ''
         widgets = [
             widget() if isinstance(widget, type) else widget for _ in range(size)
         ]
@@ -284,6 +285,7 @@ class InlineArrayWidget(forms.MultiWidget):
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
+        context['widget']['placeholder'] = self.placeholder
         invalid_count = len(
             list(
                 filter(
@@ -334,8 +336,10 @@ class InlineArrayField(SimpleArrayField):
         delimiter=",",
         max_length=None,
         min_length=None,
+        placeholder=None,
         **kwargs,
     ):
+        self.placeholder = placeholder or ''
         self.add_help_text = kwargs.pop("help_text", None)
         super().__init__(
             base_field,
@@ -349,6 +353,7 @@ class InlineArrayField(SimpleArrayField):
             size=size,
             item_label=item_label,
             add_button_text=add_button_text,
+            placeholder=placeholder,
         )
 
     def get_bound_field(self, form, field_name):

--- a/app/org_eleicoes/votepeloclima/candidature/forms.py
+++ b/app/org_eleicoes/votepeloclima/candidature/forms.py
@@ -365,6 +365,7 @@ class TrackForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
         item_label="Realização",
         add_button_text="ADICIONAR MARCO",
         help_text="Adicione momentos e realizações marcantes da sua trajetória.",
+        placeholder="Recebi o Prêmio XYZ pela Iniciativa Ambiental",
     )
 
     def clean_milestones(self):

--- a/app/org_eleicoes/votepeloclima/candidature/forms.py
+++ b/app/org_eleicoes/votepeloclima/candidature/forms.py
@@ -363,7 +363,7 @@ class TrackForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
         required=False,
         label="Histórico de atuação",
         item_label="Realização",
-        add_button_text="Adicionar outra realização",
+        add_button_text="ADICIONAR MARCO",
         help_text="Adicione momentos e realizações marcantes da sua trajetória.",
     )
 

--- a/app/org_eleicoes/votepeloclima/candidature/static/js/inline-array-widget.js
+++ b/app/org_eleicoes/votepeloclima/candidature/static/js/inline-array-widget.js
@@ -1,47 +1,59 @@
 (function ($) {
     "use strict";
-    $(function () {
-        const maxSize = $('#inline-array-add').data('size');
+    $(document).ready(function () {
+        const $inlineArrayAdd = $('#inline-array-add');
+        const maxSize = $inlineArrayAdd.data('size');
         const name = $('#inline-array').data('name');
-        
+
         function updateInlineArray() {
-            const totalInputs = $('#inline-array li').length;
+            const $inputs = $('#inline-array li input');
+            const totalInputs = $inputs.length;
+            const lastInputValue = $inputs.last().val().trim();
+
             if (totalInputs === 1) {
                 $('#inline-array li').find('button').hide();
             } else {
                 $('#inline-array li').find('button').show();
             }
 
-            if (totalInputs === maxSize) {
-                $('#inline-array-add').attr('disabled', 'disabled');
+            if (totalInputs >= maxSize || lastInputValue === "") {
+                $inlineArrayAdd.attr('disabled', 'disabled');
             } else {
-                $('#inline-array-add').removeAttr('disabled');
+                $inlineArrayAdd.removeAttr('disabled');
             }
 
+            // Atualizar os nomes dos inputs
             $('#inline-array li').each((i, item) => {
-                $(item).find('input').attr('name', `${name}_${i}`)
-            })
+                $(item).find('input').attr('name', `${name}_${i}`);
+            });
         }
 
-        $('#inline-array-add').on("click", () => {
-            const totalInputs = $('#inline-array li').length;
-            if (totalInputs < maxSize) {
-                const $div = $('#inline-array li').first().clone();
-                console.log($div);
-                console.log("asdadasdasd")
-                $div.find('input').val('');
-                $div.find('button').show();
-                $('#inline-array ol').append($div);
+        $inlineArrayAdd.off("click").on("click", () => {
+            const $inputs = $('#inline-array li input');
+            const lastInputValue = $inputs.last().val().trim();
+            const totalInputs = $inputs.length;
+
+            if (lastInputValue !== "" && totalInputs < maxSize) {
+                const $firstItem = $('#inline-array li').first().clone();
+                $firstItem.find('input').val('');
+                $firstItem.find('button').show();
+                $('#inline-array ol').append($firstItem);
                 updateInlineArray();
             }
         });
 
         function inlineDelete(target) {
-            $(target).parent().parent().remove();
+            $(target).closest('li').remove();
             updateInlineArray();
-        };
+        }
 
         updateInlineArray();
+
+        // Adicionar eventos para atualização em tempo real dos campos
+        $('#inline-array').on('input', 'input', function() {
+            updateInlineArray();
+        });
+
         window.inlineDelete = inlineDelete;
     });
 }(jQuery));

--- a/app/org_eleicoes/votepeloclima/candidature/templates/forms/widgets/inline_array.html
+++ b/app/org_eleicoes/votepeloclima/candidature/templates/forms/widgets/inline_array.html
@@ -13,6 +13,7 @@
                     id="{{ subwidget.id }}"
                     {% if subwidget.value %} value="{{ subwidget.value|stringformat:'s' }}"{% endif %}
                     {% include "django/forms/widgets/attrs.html" with widget=subwidget %}
+                    placeholder="{{ widget.placeholder|default:'' }}"
                 />
                 {% if not subwidget.attrs.disabled %}
                 <button type="button" class="btn btn-outline-danger ms-2" onclick="inlineDelete(this)">


### PR DESCRIPTION
### Contexto
Após o design review foi identificado o seguinte comportamento no botão de adicionar novos marcos ou redes sociais:
"Ao clicar em adicionar outra realização e rede social, adiciona 2 campos de uma vez (exemplo: se tem 1, e clico em adicionar outra, adiciona a 2 e 3)"

### Resolução
Agora a lógica só permite que seja adicionado mais um campo, caso o último não esteja vazio. Isso melhora a usabilidade e também corrige esse problema no JavaScript de double click.

### Link da Tarefa/Issue
- [x] [Criar campo Inline para preenchimento de Redes Sociais e Histórico de Atuação](https://app.asana.com/0/1161468210277385/1207847566017471/f)