### PR TITLE
fix(votepeloclima): fix static file reference in CheckoutForm label

### DIFF
--- a/app/org_eleicoes/votepeloclima/candidature/forms.py
+++ b/app/org_eleicoes/votepeloclima/candidature/forms.py
@@ -580,9 +580,14 @@ class ProfileForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
 
 
 class CheckoutForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
-    is_valid = HTMLBooleanField(
-        label=f'Ao preencher o formulário e se cadastrar na Campanha, você está ciente de que seus dados pessoais serão tratados de acordo com o <a href="{static("docs/aviso-de-privacidade-candidaturas.pdf")}" target="_blank">Aviso de Privacidade</a>.'
-    )
+    is_valid = HTMLBooleanField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        privacy_url = static('docs/aviso-de-privacidade-candidaturas.pdf')
+        self.fields['is_valid'].label = (
+            f'Ao preencher o formulário e se cadastrar na Campanha, você está ciente de que seus dados pessoais serão tratados de acordo com o <a href="{privacy_url}" target="_blank">Aviso de Privacidade</a>.'
+        )
 
     class Meta:
         title = "Confirmar informações"


### PR DESCRIPTION
### Contexto
Após a inclusão do PDF na tela de checkout apresentou o seguinte erro ao executar o projeto:
`ValueError: Missing staticfiles manifest entry for 'docs/aviso-de-privacidade-candidaturas.pdf'`

O problema estava ocorrendo porque o uso da função static diretamente na definição do label do campo is_valid não funciona, porque o Django ainda não processou os arquivos estáticos na fase em que o formulário é definido. Por isso coloquei dentro do __init__ e usei uma url para colocar no path.



