### PR TITLE
Adjusts on ballot name and number id at register form

### DIFF
--- a/app/org_eleicoes/votepeloclima/candidature/forms.py
+++ b/app/org_eleicoes/votepeloclima/candidature/forms.py
@@ -116,23 +116,7 @@ class AppointmentForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
 class PersonalForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
     legal_name = forms.CharField(
         label="Nome",
-        help_text="Nome da pessoa que possui os dados registrados no TSE.",
         widget=forms.TextInput(attrs={"placeholder": "Digite seu nome completo"}),
-    )
-    ballot_name = forms.CharField(
-        label="Nome na urna",
-        help_text="Nome público, registrado no TSE.",
-        widget=forms.TextInput(
-            attrs={"placeholder": "Digite o nome que aparecerá na urna"}
-        ),
-    )
-    birth_date = forms.DateField(
-        label="Data de nascimento",
-        widget=DatePickerInput(
-            attrs={"placeholder": "dd/mm/yyyy"},
-            options={"locale": "pt-BR", "format": "DD/MM/YYYY"},
-        ),
-        localize="pt-BR",
     )
     email = forms.EmailField(
         label="E-mail",
@@ -145,13 +129,21 @@ class PersonalForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
             mask="000.000.000-00", attrs={"placeholder": "Digite seu CPF"}
         ),
     )
-
+    birth_date = forms.DateField(
+        label="Data de nascimento",
+        widget=DatePickerInput(
+            attrs={"placeholder": "dd/mm/yyyy"},
+            options={"locale": "pt-BR", "format": "DD/MM/YYYY"},
+        ),
+        localize="pt-BR",
+    )
+    
     class Meta:
         title = "Informações pessoais"
         description = "Vamos lá! Essas informações são essenciais para verificar sua candidatura e garantir a segurança. Se for uma candidatura coletiva, a pessoa responsável deve ter os dados registrados no TSE."
         model = CandidatureFlow
         entangled_fields = {
-            "properties": ["legal_name", "ballot_name", "birth_date", "email", "cpf"]
+            "properties": ["legal_name", "email", "cpf", "birth_date"]
         }
         untangled_fields = []
 
@@ -165,10 +157,9 @@ class PersonalForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
         self.helper.layout = Layout(
             Div(
                 Div(Field("legal_name"), css_class="g-col-12 g-col-md-6"),
-                Div(Field("ballot_name"), css_class="g-col-12 g-col-md-6"),
-                Div(Field("birth_date"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("email"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("cpf"), css_class="g-col-12 g-col-md-6"),
+                Div(Field("birth_date"), css_class="g-col-12 g-col-md-6"),
                 css_class="grid",
                 style="grid-row-gap:0;",
             )
@@ -176,10 +167,17 @@ class PersonalForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
 
 
 class ApplicationForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
+    ballot_name = forms.CharField(
+        label="Nome na urna",
+        help_text="Nome público, registrado no TSE.",
+        widget=forms.TextInput(
+            attrs={"placeholder": "Digite o nome que aparecerá na urna"}
+        ),
+    )
     number_id = forms.IntegerField(
-        label="Número de identificação",
+        label="Número na urna",
         min_value=1,
-        help_text="Número fornecido pelo TSE",
+        help_text="Número da candidatura",
         widget=forms.NumberInput(
             attrs={"placeholder": "Digite seu número de identificação"}
         ),
@@ -227,6 +225,7 @@ class ApplicationForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
         model = CandidatureFlow
         entangled_fields = {
             "properties": [
+                "ballot_name",
                 "number_id",
                 "intended_position",
                 "state",
@@ -246,15 +245,16 @@ class ApplicationForm(EntangledModelFormMixin, DisabledMixin, forms.ModelForm):
         # TODO: investigar porque quando usamos layout o select2 duplica o campo
         self.helper.layout = Layout(
             Div(
+                Div(Field("ballot_name"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("number_id"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("intended_position"), css_class="g-col-12 g-col-md-6"),
+                Div(Field("political_party"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("state"), css_class="g-col-12 g-col-md-6"),
                 Div(Field("city"), css_class="g-col-12 g-col-md-6"),
                 Div(
                     NoCrispyField("is_collective_mandate"),
                     css_class="g-col-12 g-col-md-6 mb-3",
                 ),
-                Div(Field("political_party"), css_class="g-col-12 g-col-md-6"),
                 Div(
                     HTML(
                         """


### PR DESCRIPTION
### Contexto
Já tivemos algumas inscrições em que as candidaturas colocaram outro número no campo de numero da urna e confundiram o campo "nome na urna" com número, imaginamos que seja pq o label e o posicionamento dos campos estão gerando confusão.

### Link da Tarefa/Issue
- [ ] [[VPC] Alterar label do campo "número de identificação" e posição](https://app.asana.com/0/1161468210277385/1208138367529652/f)

### Screenshots
<img width="988" alt="Captura de Tela 2024-08-26 às 15 37 40" src="https://github.com/user-attachments/assets/44f895be-759b-4bb9-afb3-09ca135ac5ee">
<img width="1028" alt="Captura de Tela 2024-08-26 às 15 36 51" src="https://github.com/user-attachments/assets/a1df8c0e-7f57-49e3-99ad-824584d87a61">
ents/assets/c14681b5-a712-4c6c-b32c-037edb7db3ee">
