### PR TITLE
Feature/improvements django admin

### DIFF
--- a/app/org_eleicoes/votepeloclima/candidature/admin.py
+++ b/app/org_eleicoes/votepeloclima/candidature/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django import forms
+from entangled.forms import EntangledModelForm
 
 from .models import Candidature, CandidatureFlow
 
@@ -12,7 +13,7 @@ class CandidatureAdmin(admin.ModelAdmin):
         return False
 
 
-class CandidatureFlowAdminForm(forms.ModelForm):
+class CandidatureFlowAdminForm(EntangledModelForm):
     legal_name = forms.CharField(label='Nome Legal', required=True)
     cpf = forms.CharField(label='CPF', required=True)
     email = forms.EmailField(label='Email', required=True)
@@ -32,54 +33,14 @@ class CandidatureFlowAdminForm(forms.ModelForm):
 
     class Meta:
         model = CandidatureFlow
-        fields = [
-            'photo', 'video', 'status',
-            'legal_name', 'cpf', 'email', 'birth_date',
-            'ballot_name', 'number_id', 'intended_position', 'state', 'city',
-            'political_party', 'deputy_mayor', 'deputy_mayor_political_party'
-        ]
+        entangled_fields = {'properties': [
+            'legal_name', 'cpf', 'email', 'birth_date', 
+            'ballot_name', 'number_id', 'intended_position', 
+            'state', 'city', 'political_party', 
+            'deputy_mayor', 'deputy_mayor_political_party'
+        ]}
+        untangled_fields = ['photo', 'video', 'status']
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        
-        # Inicializar os campos do formulário com os valores do JSON `properties`
-        if self.instance and self.instance.properties:
-            props = self.instance.properties
-            self.fields['legal_name'].initial = props.get('legal_name', '')
-            self.fields['cpf'].initial = props.get('cpf', '')
-            self.fields['email'].initial = props.get('email', '')
-            self.fields['birth_date'].initial = props.get('birth_date', '')
-            self.fields['ballot_name'].initial = props.get('ballot_name', '')
-            self.fields['number_id'].initial = props.get('number_id', '')
-            self.fields['intended_position'].initial = props.get('intended_position', '')
-            self.fields['state'].initial = props.get('state', '')
-            self.fields['city'].initial = props.get('city', '')
-            self.fields['political_party'].initial = props.get('political_party', '')
-            self.fields['deputy_mayor'].initial = props.get('deputy_mayor', '')
-            self.fields['deputy_mayor_political_party'].initial = props.get('deputy_mayor_political_party', '')
-
-    def save(self, commit=True):
-        instance = super().save(commit=False)
-        properties = instance.properties or {}
-
-        # Atualizar o JSON `properties` com os dados do formulário
-        properties['legal_name'] = self.cleaned_data.get('legal_name')
-        properties['cpf'] = self.cleaned_data.get('cpf')
-        properties['email'] = self.cleaned_data.get('email')
-        properties['birth_date'] = self.cleaned_data.get('birth_date')
-        properties['ballot_name'] = self.cleaned_data.get('ballot_name')
-        properties['number_id'] = self.cleaned_data.get('number_id')
-        properties['intended_position'] = self.cleaned_data.get('intended_position')
-        properties['state'] = self.cleaned_data.get('state')
-        properties['city'] = self.cleaned_data.get('city')
-        properties['political_party'] = self.cleaned_data.get('political_party')
-        properties['deputy_mayor'] = self.cleaned_data.get('deputy_mayor')
-        properties['deputy_mayor_political_party'] = self.cleaned_data.get('deputy_mayor_political_party')
-
-        instance.properties = properties
-        if commit:
-            instance.save()
-        return instance
 
 class CandidatureFlowAdmin(admin.ModelAdmin):
     form = CandidatureFlowAdminForm

--- a/app/org_eleicoes/votepeloclima/candidature/admin.py
+++ b/app/org_eleicoes/votepeloclima/candidature/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django import forms
 
 from .models import Candidature, CandidatureFlow
 
@@ -11,9 +12,105 @@ class CandidatureAdmin(admin.ModelAdmin):
         return False
 
 
+class CandidatureFlowAdminForm(forms.ModelForm):
+    legal_name = forms.CharField(label='Nome Legal', required=True)
+    cpf = forms.CharField(label='CPF', required=True)
+    email = forms.EmailField(label='Email', required=True)
+    birth_date = forms.DateField(
+        label='Data de Nascimento', 
+        required=False, 
+        widget=forms.DateInput(attrs={'type': 'date'})
+    )
+    ballot_name = forms.CharField(label='Nome na Urna', required=True)
+    number_id = forms.CharField(label='Número de Identificação', required=True)
+    intended_position = forms.CharField(label='Cargo Pretendido', required=True)
+    state = forms.CharField(label='Estado', required=True)
+    city = forms.CharField(label='Cidade', required=True)
+    political_party = forms.CharField(label='Partido Político', required=True)
+    deputy_mayor = forms.CharField(label='Vice-prefeito', required=False)
+    deputy_mayor_political_party = forms.CharField(label='Partido do Vice-prefeito', required=False)
+
+    class Meta:
+        model = CandidatureFlow
+        fields = [
+            'photo', 'video', 'status',
+            'legal_name', 'cpf', 'email', 'birth_date',
+            'ballot_name', 'number_id', 'intended_position', 'state', 'city',
+            'political_party', 'deputy_mayor', 'deputy_mayor_political_party'
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        # Inicializar os campos do formulário com os valores do JSON `properties`
+        if self.instance and self.instance.properties:
+            props = self.instance.properties
+            self.fields['legal_name'].initial = props.get('legal_name', '')
+            self.fields['cpf'].initial = props.get('cpf', '')
+            self.fields['email'].initial = props.get('email', '')
+            self.fields['birth_date'].initial = props.get('birth_date', '')
+            self.fields['ballot_name'].initial = props.get('ballot_name', '')
+            self.fields['number_id'].initial = props.get('number_id', '')
+            self.fields['intended_position'].initial = props.get('intended_position', '')
+            self.fields['state'].initial = props.get('state', '')
+            self.fields['city'].initial = props.get('city', '')
+            self.fields['political_party'].initial = props.get('political_party', '')
+            self.fields['deputy_mayor'].initial = props.get('deputy_mayor', '')
+            self.fields['deputy_mayor_political_party'].initial = props.get('deputy_mayor_political_party', '')
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        properties = instance.properties or {}
+
+        # Atualizar o JSON `properties` com os dados do formulário
+        properties['legal_name'] = self.cleaned_data.get('legal_name')
+        properties['cpf'] = self.cleaned_data.get('cpf')
+        properties['email'] = self.cleaned_data.get('email')
+        properties['birth_date'] = self.cleaned_data.get('birth_date')
+        properties['ballot_name'] = self.cleaned_data.get('ballot_name')
+        properties['number_id'] = self.cleaned_data.get('number_id')
+        properties['intended_position'] = self.cleaned_data.get('intended_position')
+        properties['state'] = self.cleaned_data.get('state')
+        properties['city'] = self.cleaned_data.get('city')
+        properties['political_party'] = self.cleaned_data.get('political_party')
+        properties['deputy_mayor'] = self.cleaned_data.get('deputy_mayor')
+        properties['deputy_mayor_political_party'] = self.cleaned_data.get('deputy_mayor_political_party')
+
+        instance.properties = properties
+        if commit:
+            instance.save()
+        return instance
+
 class CandidatureFlowAdmin(admin.ModelAdmin):
+    form = CandidatureFlowAdminForm
     list_filter = ("status", )
     list_display = ("legal_name", "email", "political_party", "status")
+    
+    fieldsets = (
+        (None, {
+            'fields': ('photo', 'video', 'status')
+        }),
+        ('Informações Pessoais', {
+            'fields': (
+                'legal_name', 
+                'cpf', 
+                'email', 
+                'birth_date'
+            )
+        }),
+        ('Dados de Candidatura', {
+            'fields': (
+                'ballot_name', 
+                'number_id',
+                'intended_position',
+                'state', 
+                'city', 
+                'political_party', 
+                'deputy_mayor', 
+                'deputy_mayor_political_party'
+            )
+        }),
+    )
 
     @admin.display
     def legal_name(self, obj):

--- a/app/org_eleicoes/votepeloclima/candidature/models.py
+++ b/app/org_eleicoes/votepeloclima/candidature/models.py
@@ -13,31 +13,31 @@ from .locations_utils import get_choices, get_states
 
 
 class Candidature(models.Model):
-    legal_name = models.CharField(max_length=150)
-    ballot_name = models.CharField(max_length=100)
-    birth_date = models.DateField()
-    email = models.EmailField()
-    cpf = models.CharField(max_length=30)
-    number_id = models.PositiveIntegerField()
-    intended_position = models.CharField(max_length=50, choices=IntendedPosition.choices)
-    deputy_mayor = models.CharField(max_length=140, blank=True, null=True)
-    deputy_mayor_political_party = models.CharField(max_length=60, blank=True, null=True)
-    state = models.CharField(max_length=10)
-    city = models.CharField(max_length=60)
-    is_collective_mandate = models.BooleanField(default=False, blank=True)
-    political_party = models.CharField(max_length=60, choices=PoliticalParty.choices)
-    video = models.FileField(upload_to="candidatures/videos/", null=True, blank=True)
-    photo = models.FileField(upload_to="candidatures/photos/", null=True, blank=True)
-    gender = models.CharField(max_length=30, choices=Gender.choices)
-    color = models.CharField(max_length=30, choices=Color.choices)
-    sexuality = models.CharField(max_length=30, null=True, blank=True, choices=Sexuality.choices)
-    social_media = models.JSONField(blank=True, null=True, default=list)
-    education = models.CharField(max_length=50, null=True, blank=True, choices=Education.choices)
-    employment = models.CharField(max_length=50, null=True, blank=True)
-    short_description = models.TextField()
-    milestones = models.JSONField(blank=True, null=True, default=list)
-    proposes = models.JSONField(blank=True)
-    appointments = models.JSONField(blank=True)
+    legal_name = models.CharField(max_length=150, verbose_name="Nome")
+    ballot_name = models.CharField(max_length=100, verbose_name="Nome na Urna")
+    birth_date = models.DateField(verbose_name="Data de Nascimento")
+    email = models.EmailField(verbose_name="E-mail")
+    cpf = models.CharField(max_length=30, verbose_name="CPF")
+    number_id = models.PositiveIntegerField(verbose_name="Número na Urna")
+    intended_position = models.CharField(max_length=50, choices=IntendedPosition.choices, verbose_name="Cargo Pretendido")
+    deputy_mayor = models.CharField(max_length=140, blank=True, null=True, verbose_name="Vice-prefeito")
+    deputy_mayor_political_party = models.CharField(max_length=60, blank=True, null=True, verbose_name="Partido do Vice-prefeito")
+    state = models.CharField(max_length=10, verbose_name="Estado")
+    city = models.CharField(max_length=60, verbose_name="Cidade")
+    is_collective_mandate = models.BooleanField(default=False, blank=True, verbose_name="Mandato Coletivo")
+    political_party = models.CharField(max_length=60, choices=PoliticalParty.choices, verbose_name="Partido Político")
+    video = models.FileField(upload_to="candidatures/videos/", null=True, blank=True, verbose_name="Vídeo")
+    photo = models.FileField(upload_to="candidatures/photos/", null=True, blank=True, verbose_name="Foto")
+    gender = models.CharField(max_length=30, choices=Gender.choices, verbose_name="Gênero")
+    color = models.CharField(max_length=30, choices=Color.choices, verbose_name="Raça")
+    sexuality = models.CharField(max_length=30, null=True, blank=True, choices=Sexuality.choices, verbose_name="Sexualidade")
+    social_media = models.JSONField(blank=True, null=True, default=list, verbose_name="Redes Sociais")
+    education = models.CharField(max_length=50, null=True, blank=True, choices=Education.choices, verbose_name="Educação")
+    employment = models.CharField(max_length=50, null=True, blank=True, verbose_name="Ocupação")
+    short_description = models.TextField(verbose_name="Descrição Curta")
+    milestones = models.JSONField(blank=True, null=True, default=list, verbose_name="Marcos")
+    proposes = models.JSONField(blank=True, verbose_name="Propostas")
+    appointments = models.JSONField(blank=True, verbose_name="Compromissos")
 
     # friendly url by ballot_name
     slug = models.SlugField(max_length=100, unique=True, blank=True, null=True)
@@ -70,14 +70,15 @@ class Candidature(models.Model):
 
 class CandidatureFlow(models.Model):
     # Propriedades só podem ser editadas quando status for `draft`
-    photo = models.ImageField(upload_to="candidatures/photos/", null=True)
-    video = models.FileField(upload_to="candidatures/videos/", null=True, blank=True)
+    photo = models.ImageField(upload_to="candidatures/photos/", null=True, verbose_name="Foto")
+    video = models.FileField(upload_to="candidatures/videos/", null=True, blank=True, verbose_name="Vídeo")
 
-    properties = models.JSONField(blank=True, encoder=DjangoJSONEncoder, default=dict)
+    properties = models.JSONField(blank=True, encoder=DjangoJSONEncoder, default=dict, verbose_name="Propriedades")
     status = models.CharField(
         max_length=50,
         choices=CandidatureFlowStatus.choices,
         default=CandidatureFlowStatus.draft,
+        verbose_name="Status",
     )
 
     # Registro das etapas de validação
@@ -85,7 +86,7 @@ class CandidatureFlow(models.Model):
     # Quando foi validado? Data da ação
     # Validado ou não
     # Comentário sobre
-    validations = models.JSONField(blank=True, null=True)
+    validations = models.JSONField(blank=True, null=True, verbose_name="Validações")
 
     # Etapa 2
     # - Preenchimento da Candidatura
@@ -93,14 +94,14 @@ class CandidatureFlow(models.Model):
     # - Validadores automatizados
     # - Validatores manuais
     candidature = models.OneToOneField(
-        Candidature, null=True, on_delete=models.SET_NULL
+        Candidature, null=True, blank=True, on_delete=models.SET_NULL, verbose_name="Candidatura"
     )
 
     # Etapa 1
     # - Criar usuário desabilitado `is_active=False`
     # - Enviar e-mail para validar o usuário e criar uma senha de acesso
     # - Habilitar usuário `is_active=True`
-    user = models.OneToOneField(User, null=True, on_delete=models.SET_NULL)
+    user = models.OneToOneField(User, null=True, on_delete=models.SET_NULL, verbose_name="Usuário")
 
     class Meta:
         verbose_name = "Formulário"


### PR DESCRIPTION
### Contexto
Atualizar listagem de candidaturas submetidas (formulário) ao admin do Django com os campos do cadastro para a equipe poder acompanhar os candidatos reprovados e atualizar o status manualmente quando for preciso.

### Link da Tarefa/Issue
- [x] [Django Admin: Listagem de candidaturas para acompanhar validação manualmente](https://app.asana.com/0/1161468210277385/1207704589275817/f)

### Requisitos
- [x] Retirar a obrigatoriedade do campo "candidature" pra equipe poder atualizar o status da candidatura pelo admin.
- [x] Trazer todos os campos da candidatura preenchidos no formulário (nome, nome na urna, etc etc) e o status.
- [x] Deixar os labels dos campos em português para o entendimento da equipe.

### Screenshots
<img width="1440" alt="Captura de Tela 2024-08-28 às 12 10 45" src="https://github.com/user-attachments/assets/d983e135-3f09-4dd2-ba1e-7368d6b528db">
