### PR TITLE
Preserve commas in milestones without splitting entries

### DIFF
--- a/app/org_eleicoes/votepeloclima/candidature/fields.py
+++ b/app/org_eleicoes/votepeloclima/candidature/fields.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 from django import forms
@@ -287,26 +288,24 @@ class InlineArrayWidget(forms.MultiWidget):
                 "js/inline-array-widget.js",
             ],
         )
-
+    
     def decompress(self, value):
         if isinstance(value, list):
             return value
         if value is None:
             return []
-        return [v.strip() for v in value.split(",")]
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return []
 
     def value_from_datadict(self, data, files, name):
         values = []
+        for key, value in data.items():
+            if key.startswith(f"{name}_") and value.strip():
+                values.append(value.strip())
 
-        # Used when save values in model like a list
-        if name in data:
-            values = data.get(name)
-        else:
-            for key, value in data.items():
-                if key.startswith(f"{name}_"):
-                    values.append(value)
-
-        return values
+        return json.dumps(values)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)

--- a/app/org_eleicoes/votepeloclima/candidature/fields.py
+++ b/app/org_eleicoes/votepeloclima/candidature/fields.py
@@ -288,7 +288,7 @@ class InlineArrayWidget(forms.MultiWidget):
                 "js/inline-array-widget.js",
             ],
         )
-    
+
     def decompress(self, value):
         if isinstance(value, list):
             return value


### PR DESCRIPTION
### Contexto
Perceberam um bug no campo de marcos quando é utilizado vírgulas no corpo do texto. Este PR corrige um problema onde o uso de vírgulas nos marcos (milestones) estava dividindo o texto em múltiplas entradas. A solução implementada agora trata as vírgulas dentro dos valores corretamente, permitindo que os marcos sejam salvos como uma lista JSON.

### Link da Tarefa/Issue
- [ ] [[Bug impeditivo] Histórico de atuação](https://app.asana.com/0/1161468210277385/1208180721958359/f)


### Como foi implementado
Foi alterado todo o tratamento do widget para manipulação de JSON. Utilizando JSON para encapsular os dados, você garante que textos complexos, incluindo aqueles com vírgulas, sejam tratados corretamente.

Se o usuário adicionasse dois marcos separados por vírgula, eles poderiam aparecer assim:
`"Em 2016 eu organizei um evento, e foi em Brasília, Outro marco importante"`

Com a nova abordagem, os dados são armazenados como uma lista JSON. Se o usuário adicionar os mesmos marcos, eles serão armazenados assim:
`[
    "Em 2016 eu organizei um evento, e foi em Brasília",
    "Outro marco importante"
]`


