### PR TITLE
Adjusted pdf viewer styles

### DIFF
--- a/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
+++ b/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
@@ -30,7 +30,7 @@
         pageNum = 1,
         pageRendering = false,
         pageNumPending = null,
-        scale = 1.5,
+        scale = 1.0,
         canvas = document.getElementById('the-canvas'),
         ctx = canvas.getContext('2d');
   
@@ -43,12 +43,21 @@
       // Using promise to fetch the page
       pdfDoc.getPage(num).then(function(page) {
         var viewport = page.getViewport({scale: scale});
+        // Calcula a escala para caber no container
+        var container = canvas.parentElement;
+        var viewport = page.getViewport({scale: 1.0});
+        
+        // Ajusta a escala para caber na largura do container
+        scale = Math.min((container.clientWidth - 20) / viewport.width, 1.5);
+        
+        // Cria novo viewport com a escala ajustada
+        viewport = page.getViewport({scale: scale * (window.devicePixelRatio || 1)});
+        
+        // Ajusta o canvas
         canvas.height = viewport.height;
         canvas.width = viewport.width;
-
-        // Melhora a qualidade de renderização
-        var outputScale = window.devicePixelRatio || 1;
-        ctx.scale(outputScale, outputScale);
+        canvas.style.width = (viewport.width / (window.devicePixelRatio || 1)) + 'px';
+        canvas.style.height = (viewport.height / (window.devicePixelRatio || 1)) + 'px';
   
         // Render PDF page into canvas context
         var renderContext = {

--- a/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
+++ b/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
@@ -45,8 +45,6 @@
         var viewport = page.getViewport({scale: scale});
         canvas.height = viewport.height;
         canvas.width = viewport.width;
-        canvas.style.width = '100%';
-        canvas.style.height = 'auto';
 
         // Melhora a qualidade de renderização
         var outputScale = window.devicePixelRatio || 1;

--- a/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
+++ b/app/org_nossas/nossas/plugins/templates/nossas/plugins/pdf.html
@@ -30,7 +30,7 @@
         pageNum = 1,
         pageRendering = false,
         pageNumPending = null,
-        scale = 0.8,
+        scale = 1.5,
         canvas = document.getElementById('the-canvas'),
         ctx = canvas.getContext('2d');
   
@@ -45,6 +45,12 @@
         var viewport = page.getViewport({scale: scale});
         canvas.height = viewport.height;
         canvas.width = viewport.width;
+        canvas.style.width = '100%';
+        canvas.style.height = 'auto';
+
+        // Melhora a qualidade de renderização
+        var outputScale = window.devicePixelRatio || 1;
+        ctx.scale(outputScale, outputScale);
   
         // Render PDF page into canvas context
         var renderContext = {


### PR DESCRIPTION
### Contexto
A visualização de PDFs está com resolução baixa no site do Nossas.
<img width="812" alt="Captura de Tela 2025-04-29 às 11 29 45" src="https://github.com/user-attachments/assets/f66abd4e-1fd6-4516-936d-c8762d5b256f" />

### Link da Tarefa/Issue
- [x] [Problema com baixa resolução do PDFviewer no site do Nossas](https://app.asana.com/1/1105567501435500/project/1161468210277385/task/1210085476241230?focus=true)

### Resolução
Foram ajustados alguns parâmetros de configuração no Javascript do plugin.

### Screenshots







